### PR TITLE
Rename strategy from exec-environment to target environment

### DIFF
--- a/src/outpost/scheduling_strategy.py
+++ b/src/outpost/scheduling_strategy.py
@@ -164,7 +164,7 @@ class MustRunInGivenExecutionEnvironmentStrategy(SchedulingStrategy):
         return SchedulingDecision.DONT_SCHEDULE
 
 
-class MustRunInCurrentExecutionEnvironmentStrategy(SchedulingStrategy):
+class MustRunInTargetEnvironmentStrategy(SchedulingStrategy):
     @override
     def schedule(
         self,
@@ -226,7 +226,7 @@ class DetectImpossibleCombinationStrategy(SchedulingStrategy):
         must_run_in_current_execution_environment = bool(
             self._filter_strategies(
                 strategies,
-                MustRunInCurrentExecutionEnvironmentStrategy,
+                MustRunInTargetEnvironmentStrategy,
             )
         )
 

--- a/tests/test_scheduling_strategy.py
+++ b/tests/test_scheduling_strategy.py
@@ -27,8 +27,8 @@ from outpost.scheduling_strategy import (
     DetectImpossibleCombinationStrategy,
     InvalidCheckConfiguration,
     MustRunAgainstGivenTargetEnvironmentStrategy,
-    MustRunInCurrentExecutionEnvironmentStrategy,
     MustRunInGivenExecutionEnvironmentStrategy,
+    MustRunInTargetEnvironmentStrategy,
     SchedulingDecision,
     SchedulingStrategy,
 )
@@ -48,7 +48,7 @@ class LogSystem(Datasource):
 
 class ProductService(Datasource):
     scheduling_strategies = (
-        MustRunInCurrentExecutionEnvironmentStrategy(),
+        MustRunInTargetEnvironmentStrategy(),
         MustRunAgainstGivenTargetEnvironmentStrategy(Preprod),
     )
 
@@ -321,7 +321,7 @@ def test_invalid_exec_and_target_envs_without_intersection_but_current_required(
 
     class TargetPreprodAndCurrent(Datasource):
         scheduling_strategies = (
-            MustRunInCurrentExecutionEnvironmentStrategy(),
+            MustRunInTargetEnvironmentStrategy(),
             MustRunAgainstGivenTargetEnvironmentStrategy(Preprod),
         )
 


### PR DESCRIPTION
The name "MustRunInCurrentExecutionEnvironment" is a tautology, in that if a check is running, it is inevitably running in the current execution environment. What this strategy is actually saying is that the execution environment the check can run in must be the target environment the check is running for, hence the name change to
"MustRunInTargetEnvironment" to better describe this.