### PR TITLE
Support direct use of datasource-factory as check argument type

### DIFF
--- a/src/watchpost/datasource.py
+++ b/src/watchpost/datasource.py
@@ -60,7 +60,7 @@ class FromFactory:
         **kwargs: Any,
     ):
         self.factory_type: type[DatasourceFactory] | None
-        if isinstance(factory, type):
+        if factory is None or isinstance(factory, type):
             self.factory_type = factory
             self.args = args
         else:


### PR DESCRIPTION
If a factory does not require any arguments for its `new` method, having to specify `Annotated[MyFactory, FromFactory()]` is somewhat superfluous. This change makes it possible to provide just `MyFactory` instead.

Closes #42.